### PR TITLE
Rename Object class for PHP7.2 compatibility.

### DIFF
--- a/init.php
+++ b/init.php
@@ -4,7 +4,7 @@
 require(dirname(__FILE__) . '/lib/BlockScore.php');
 
 // Helpers
-require(dirname(__FILE__) . '/lib/Object.php');
+require(dirname(__FILE__) . '/lib/BaseObject.php');
 require(dirname(__FILE__) . '/lib/ApiRequestor.php');
 require(dirname(__FILE__) . '/lib/ApiResource.php');
 require(dirname(__FILE__) . '/lib/Util/Util.php');

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -2,7 +2,7 @@
 
 namespace BlockScore;
 
-class ApiResource extends Object
+class ApiResource extends BaseObject
 {
     // @var array An array mapping the API resources to their class name.
     private static $resources = array(
@@ -34,7 +34,7 @@ class ApiResource extends Object
     }
 
     /**
-     * @return Object Returns the "refreshed" Object from the BlockScore API.
+     * @return BaseObject Returns the "refreshed" BaseObject from the BlockScore API.
      */
     public function refresh()
     {
@@ -64,7 +64,7 @@ class ApiResource extends Object
     /**
      * @param string $id The ID of the object to retrieve.
      *
-     * @return Object The retrieved instance.
+     * @return BaseObject The retrieved instance.
      */
     protected static function _retrieve($id)
     {
@@ -76,7 +76,7 @@ class ApiResource extends Object
     /**
      * @param array|null $options The options to use for the response.
      *
-     * @return array An array of Objects.
+     * @return array An array of BaseObjects.
      */
     protected static function _all($options = null)
     {
@@ -88,7 +88,7 @@ class ApiResource extends Object
     /**
      * @param array $params The parameters to use.
      *
-     * @return Object The created BlockScore Object.
+     * @return BaseObject The created BlockScore BaseObject.
      */
     protected static function _create($params)
     {
@@ -98,7 +98,7 @@ class ApiResource extends Object
     }
 
     /**
-     * @return Object The refreshed (and now deleted) instance.
+     * @return BaseObject The refreshed (and now deleted) instance.
      */
     protected function _delete()
     {
@@ -109,7 +109,7 @@ class ApiResource extends Object
     }
 
     /**
-     * @return Object The refreshed instance after saving unsaved attributes.
+     * @return BaseObject The refreshed instance after saving unsaved attributes.
      */
     protected function _save()
     {

--- a/lib/BaseObject.php
+++ b/lib/BaseObject.php
@@ -6,14 +6,14 @@ use ArrayAccess;
 use InvalidArgumentException;
 
 /**
- *  This Object class exists to make it easier to work with objects.
+ *  This class exists to make it easier to work with objects.
  *  Since we want to interact with objects after retrieving them (edit/delete),
  *    we need to be able to track the original values of the attributes and
  *    also the new values of certain attributes.
  *  Anything extending from this class will also be able to access the original
  *    values by using $var->$value
  */
-class Object implements ArrayAccess
+class BaseObject implements ArrayAccess
 {
 
     // @var array Contains the values of the object.
@@ -107,7 +107,7 @@ class Object implements ArrayAccess
     /**
      * @param array $values The values to construct the object with
      *
-     * @return Object The constructed Object.
+     * @return BaseObject The constructed BaseObject.
      */
     public static function constructObject($values)
     {

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -2,7 +2,7 @@
 
 namespace BlockScore\Util;
 
-use BlockScore\Object;
+use BlockScore\BaseObject;
 
 class Util
 {
@@ -16,9 +16,9 @@ class Util
     }
 
     /**
-     * @param Object(JSON) $response
+     * @param BaseObject(JSON) $response
      *
-     * @return Object Returns a "BlockScore Object" type.
+     * @return BaseObject Returns a "BlockScore BaseObject" type.
      */
     public static function convertToBlockScoreObject($response)
     {
@@ -50,12 +50,12 @@ class Util
             if (isset($types[$response->object])) {
                 $class = $types[$response->object];
             } else {
-                $class = 'BlockScore\\Object';
+                $class = 'BlockScore\\BaseObject';
             }
 
             return $class::constructObject($response);
         } else {
-            $class = 'BlockScore\\Object';
+            $class = 'BlockScore\\BaseObject';
             return $class::constructObject($response);
         }
     }

--- a/tests/CandidateTest.php
+++ b/tests/CandidateTest.php
@@ -20,7 +20,7 @@ class CandidateTest extends TestCase
     {
         $candidate = self::createTestCandidate();
         $this->assertTrue($candidate instanceof Candidate);
-        $this->assertTrue($candidate instanceof Object);
+        $this->assertTrue($candidate instanceof BaseObject);
     }
 
     public function testListAllCandidates()

--- a/tests/CompanyTest.php
+++ b/tests/CompanyTest.php
@@ -19,7 +19,7 @@ class CompanyTest extends TestCase
     {
         $company = self::createTestCompany();
         $this->assertTrue($company instanceof Company);
-        $this->assertTrue($company instanceof Object);
+        $this->assertTrue($company instanceof BaseObject);
     }
     
     public function testListAllCompanies()

--- a/tests/PersonTest.php
+++ b/tests/PersonTest.php
@@ -19,7 +19,7 @@ class PersonTest extends TestCase
     {
         $person = self::createTestPerson();
         $this->assertTrue($person instanceof Person);
-        $this->assertTrue($person instanceof Object);
+        $this->assertTrue($person instanceof BaseObject);
     }
     
     public function testListAllPeople()

--- a/tests/QuestionSetTest.php
+++ b/tests/QuestionSetTest.php
@@ -23,7 +23,7 @@ class QuestionSetTest extends TestCase
         $person = self::createTestPerson();
         $qs = $person->question_sets->create();
         $this->assertTrue($qs instanceof QuestionSet);
-        $this->assertTrue($qs instanceof Object);
+        $this->assertTrue($qs instanceof BaseObject);
     }
 
     public function testCreateQuestionSet()

--- a/tests/WatchlistTest.php
+++ b/tests/WatchlistTest.php
@@ -14,7 +14,7 @@ class WatchlistTest extends TestCase
         $candidate = self::createTestCandidate();
         $wl = $candidate->watchlists->search();
         $this->assertTrue($wl instanceof Watchlist);
-        $this->assertTrue($wl instanceof Object);
+        $this->assertTrue($wl instanceof BaseObject);
     }
     
     public function testWatchlistTestSearch()


### PR DESCRIPTION
This fixes PHP 7.2 compatibility as Object can not be a classname. The Object class has been renamed to BaseObject.